### PR TITLE
Ensure that SDS initialize is called on the correct thread.

### DIFF
--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -17,7 +17,7 @@ SdsApi::SdsApi(const LocalInfo::LocalInfo& local_info, Event::Dispatcher& dispat
                const envoy::api::v2::core::ConfigSource& sds_config,
                const std::string& sds_config_name, std::function<void()> destructor_cb,
                Api::Api& api)
-    : init_target_(fmt::format("SdsApi {}", sds_config_name), [this] { initialize(); }),
+    : init_target_(fmt::format("SdsApi {}", sds_config_name), [this, &dispatcher] { dispatcher.post([this](){ initialize(); }); }),
       local_info_(local_info), dispatcher_(dispatcher), random_(random), stats_(stats),
       cluster_manager_(cluster_manager), sds_config_(sds_config), sds_config_name_(sds_config_name),
       secret_hash_(0), clean_up_(destructor_cb), api_(api) {
@@ -65,6 +65,7 @@ void SdsApi::onConfigUpdateFailed(const EnvoyException*) {
 }
 
 void SdsApi::initialize() {
+  RELEASE_ASSERT(subscription_ == nullptr, "");
   subscription_ = Envoy::Config::SubscriptionFactory::subscriptionFromConfigSource(
       sds_config_, local_info_, dispatcher_, cluster_manager_, random_, stats_,
       "envoy.service.discovery.v2.SecretDiscoveryService.FetchSecrets",


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section 
in [PULL_REQUESTS.md](./PULL_REQUESTS.md)

*Description*:
*Risk Level*:
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
